### PR TITLE
Add Swift overlay skeleton with build tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: build test run clean
+
+build:
+	swift build
+	swiftc -o .build/debug/Asdfghjkl-cli Sources/Asdfghjkl/*.swift Sources/AsdfghjklCore/*.swift
+	@echo "Executable built at .build/debug/Asdfghjkl"
+	@echo "Alternate CLI stub built at .build/debug/Asdfghjkl-cli"
+
+test:
+	swift test
+
+run: build
+	.build/debug/Asdfghjkl
+
+clean:
+	swift package clean
+	rm -f .build/debug/Asdfghjkl-cli

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Asdfghjkl",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "Asdfghjkl", targets: ["Asdfghjkl"]),
+        .library(name: "AsdfghjklCore", targets: ["AsdfghjklCore"])
+    ],
+    targets: [
+        .target(
+            name: "AsdfghjklCore"
+        ),
+        .executableTarget(
+            name: "Asdfghjkl",
+            dependencies: ["AsdfghjklCore"]
+        ),
+        .testTarget(
+            name: "AsdfghjklTests",
+            dependencies: ["AsdfghjklCore"]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # Asdfghjkl
-Use the keyboard instead of the mouse. Inspired by Deadmau5
+
+Use the keyboard instead of the mouse. Inspired by Deadmau5.
+
+This repository currently contains a scaffolded macOS overlay app described in `PLAN.md`.
+The Swift Package builds a headless skeleton of the input, overlay, and action layers so we
+can iterate on the logic before attaching real AppKit windows and event taps.
+
+## Building and testing
+
+You can build and run the placeholder executable with the provided `Makefile`:
+
+```sh
+make build   # swift build + direct swiftc compile for quick iteration
+make test    # runs the GridLayout and overlay state tests
+make run     # runs the executable from .build/debug
+```
+
+To keep the binary alive for a quick state-machine demo, run with `ASDFGHJKL_DEMO=1`:
+
+```sh
+ASDFGHJKL_DEMO=1 .build/debug/Asdfghjkl
+```

--- a/Sources/Asdfghjkl/main.swift
+++ b/Sources/Asdfghjkl/main.swift
@@ -1,0 +1,33 @@
+import Foundation
+import AsdfghjklCore
+
+@main
+struct AsdfghjklApp {
+    static func main() {
+        let overlayController = OverlayController()
+        let inputManager = InputManager(overlayController: overlayController)
+
+        // This is a placeholder entry point for the macOS app. In a full GUI build
+        // this will be replaced by the AppKit/SwiftUI lifecycle that installs the
+        // CGEvent tap described in PLAN.md. For now we set up the scaffolding
+        // objects so they are ready for integration.
+        inputManager.start()
+
+        // Simulate a minimal run loop in debug contexts to keep the binary alive
+        // long enough to test the state machine logic without UI.
+        if ProcessInfo.processInfo.environment["ASDFGHJKL_DEMO"] == "1" {
+            runDemo(using: overlayController, inputManager: inputManager)
+        }
+    }
+
+    private static func runDemo(using overlayController: OverlayController, inputManager: InputManager) {
+        print("Asdfghjkl overlay skeleton initialised. Double-tap Cmd to toggle the overlay once event taps are wired up.")
+        overlayController.start()
+        _ = overlayController.handleKey("q")
+        _ = overlayController.handleKey("w")
+        if let target = overlayController.targetPoint {
+            print("Refined target ready at: (\(target.x), \(target.y))")
+        }
+        inputManager.cancelOverlay()
+    }
+}

--- a/Sources/AsdfghjklCore/CommandTapRecognizer.swift
+++ b/Sources/AsdfghjklCore/CommandTapRecognizer.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct CommandTapRecognizer {
+    public private(set) var cmdDown: Bool = false
+    public private(set) var cmdUsedAsModifierSinceDown: Bool = false
+    private var cmdLastTapTime: Date?
+    public var doubleTapThreshold: TimeInterval = 0.35
+
+    public mutating func handleCommandDown() {
+        cmdDown = true
+        cmdUsedAsModifierSinceDown = false
+    }
+
+    public mutating func handleCommandModifierUse() {
+        if cmdDown {
+            cmdUsedAsModifierSinceDown = true
+        }
+    }
+
+    public mutating func handleCommandUp(onDoubleTap: () -> Void) {
+        guard cmdDown else { return }
+        defer { cmdDown = false }
+
+        if cmdUsedAsModifierSinceDown {
+            cmdLastTapTime = nil
+            return
+        }
+
+        let now = Date()
+        if let last = cmdLastTapTime, now.timeIntervalSince(last) < doubleTapThreshold {
+            onDoubleTap()
+        }
+        cmdLastTapTime = now
+    }
+}

--- a/Sources/AsdfghjklCore/GridLayout.swift
+++ b/Sources/AsdfghjklCore/GridLayout.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+public struct GridPoint: Equatable {
+    public var x: Double
+    public var y: Double
+}
+
+public struct GridRect: Equatable {
+    public var origin: GridPoint
+    public var size: GridPoint
+
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.origin = GridPoint(x: x, y: y)
+        self.size = GridPoint(x: width, y: height)
+    }
+
+    public static var defaultScreen: GridRect {
+        GridRect(x: 0, y: 0, width: 1920, height: 1080)
+    }
+
+    public var minX: Double { origin.x }
+    public var minY: Double { origin.y }
+    public var width: Double { size.x }
+    public var height: Double { size.y }
+    public var midX: Double { origin.x + size.x / 2 }
+    public var midY: Double { origin.y + size.y / 2 }
+
+    public func subdividing(rows: Int, columns: Int, row: Int, column: Int) -> GridRect? {
+        guard rows > 0, columns > 0, row >= 0, column >= 0, row < rows, column < columns else {
+            return nil
+        }
+
+        let tileWidth = width / Double(columns)
+        let tileHeight = height / Double(rows)
+        let x = minX + Double(column) * tileWidth
+        let y = minY + Double(row) * tileHeight
+
+        return GridRect(x: x, y: y, width: tileWidth, height: tileHeight)
+    }
+}
+
+public struct GridCoordinate: Equatable {
+    public let row: Int
+    public let column: Int
+}
+
+public struct GridLayout {
+    public let rows: Int
+    public let columns: Int
+    public let keymap: [Character: GridCoordinate]
+
+    public init(rows: Int = 4, columns: Int = 10, keymap: [Character: GridCoordinate] = GridLayout.defaultKeymap) {
+        self.rows = rows
+        self.columns = columns
+        self.keymap = keymap
+    }
+
+    public func coordinate(for key: Character) -> GridCoordinate? {
+        keymap[Character(key.lowercased())]
+    }
+
+    public func rect(for key: Character, in rect: GridRect) -> GridRect? {
+        guard let coordinate = coordinate(for: key) else { return nil }
+        return rect.subdividing(rows: rows, columns: columns, row: coordinate.row, column: coordinate.column)
+    }
+
+    public static var defaultKeymap: [Character: GridCoordinate] {
+        let rows = [
+            "1234567890",
+            "qwertyuiop",
+            "asdfghjkl;",
+            "zxcvbnm,./"
+        ]
+
+        var mapping: [Character: GridCoordinate] = [:]
+        for (rowIndex, rowString) in rows.enumerated() {
+            for (columnIndex, char) in rowString.enumerated() {
+                mapping[char] = GridCoordinate(row: rowIndex, column: columnIndex)
+            }
+        }
+
+        return mapping
+    }
+}

--- a/Sources/AsdfghjklCore/InputManager.swift
+++ b/Sources/AsdfghjklCore/InputManager.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public final class InputManager {
+    private let overlayController: OverlayController
+    private var commandRecognizer = CommandTapRecognizer()
+
+    public init(overlayController: OverlayController) {
+        self.overlayController = overlayController
+    }
+
+    public func start() {
+        // Placeholder for CGEvent tap setup. The real implementation will listen for
+        // .flagsChanged and .keyDown events to drive the recognizer and overlay.
+        #if os(macOS)
+        print("InputManager ready for CGEvent tap installation")
+        #else
+        print("InputManager stub active (non-macOS environment)")
+        #endif
+    }
+
+    public func handleCommandDown() {
+        commandRecognizer.handleCommandDown()
+    }
+
+    public func handleCommandUp() {
+        commandRecognizer.handleCommandUp { [weak self] in
+            self?.overlayController.toggle()
+        }
+    }
+
+    public func markCommandAsModifier() {
+        commandRecognizer.handleCommandModifierUse()
+    }
+
+    @discardableResult
+    public func handleKeyPress(_ key: Character) -> GridRect? {
+        overlayController.handleKey(key)
+    }
+
+    public func handleSpacebarClick() {
+        overlayController.click()
+    }
+
+    public func cancelOverlay() {
+        overlayController.cancel()
+    }
+}

--- a/Sources/AsdfghjklCore/OverlayController.swift
+++ b/Sources/AsdfghjklCore/OverlayController.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public final class OverlayController {
+    private var state: OverlayState
+    private let gridLayout: GridLayout
+    private let screenBoundsProvider: () -> GridRect
+
+    public init(gridLayout: GridLayout = GridLayout(), screenBoundsProvider: @escaping () -> GridRect = { .defaultScreen }) {
+        self.gridLayout = gridLayout
+        self.screenBoundsProvider = screenBoundsProvider
+        self.state = OverlayState()
+    }
+
+    public var isActive: Bool { state.isActive }
+    public var targetRect: GridRect { state.currentRect }
+    public var targetPoint: GridPoint? { isActive ? state.targetPoint : nil }
+
+    public func start() {
+        let bounds = screenBoundsProvider()
+        state.reset(rect: bounds)
+        state.isActive = true
+    }
+
+    public func toggle() {
+        isActive ? cancel() : start()
+    }
+
+    public func cancel() {
+        state.isActive = false
+    }
+
+    @discardableResult
+    public func handleKey(_ key: Character) -> GridRect? {
+        guard state.isActive else { return nil }
+        guard let refined = gridLayout.rect(for: key, in: state.currentRect) else { return nil }
+        state.currentRect = refined
+        return refined
+    }
+
+    public func click() {
+        guard state.isActive else { return }
+        // TODO: Integrate CGEvent-based click once the macOS target is wired up.
+        // The skeleton keeps this as a no-op so we can build and test the state machine independently.
+        state.isActive = false
+    }
+}

--- a/Sources/AsdfghjklCore/OverlayState.swift
+++ b/Sources/AsdfghjklCore/OverlayState.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct OverlayState {
+    public var isActive: Bool = false
+    public var rootRect: GridRect = .defaultScreen
+    public var currentRect: GridRect = .defaultScreen
+
+    public var targetPoint: GridPoint {
+        GridPoint(x: currentRect.midX, y: currentRect.midY)
+    }
+
+    public mutating func reset(rect: GridRect) {
+        rootRect = rect
+        currentRect = rect
+        isActive = false
+    }
+}

--- a/Sources/AsdfghjklCore/ZoomController.swift
+++ b/Sources/AsdfghjklCore/ZoomController.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public final class ZoomController {
+    public private(set) var observedRect: GridRect
+
+    public init(initialRect: GridRect = .defaultScreen) {
+        self.observedRect = initialRect
+    }
+
+    public func update(rect: GridRect) {
+        observedRect = rect
+        // TODO: Render a magnified snapshot of the rect once hooked into AppKit.
+    }
+}

--- a/Tests/AsdfghjklTests/GridLayoutTests.swift
+++ b/Tests/AsdfghjklTests/GridLayoutTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import AsdfghjklCore
+
+final class GridLayoutTests: XCTestCase {
+    func testDefaultKeymapProvidesCoordinates() {
+        let layout = GridLayout()
+        XCTAssertEqual(layout.coordinate(for: "q"), GridCoordinate(row: 1, column: 0))
+        XCTAssertEqual(layout.coordinate(for: "m"), GridCoordinate(row: 3, column: 6))
+        XCTAssertNil(layout.coordinate(for: "!"))
+    }
+
+    func testRectSubdivisionMatchesGrid() {
+        let layout = GridLayout()
+        let root = GridRect(x: 0, y: 0, width: 100, height: 50)
+
+        let qRect = layout.rect(for: "q", in: root)
+        XCTAssertEqual(qRect, GridRect(x: 0, y: 12.5, width: 10, height: 12.5))
+
+        let zeroRect = layout.rect(for: "0", in: root)
+        XCTAssertEqual(zeroRect, GridRect(x: 90, y: 0, width: 10, height: 12.5))
+    }
+
+    func testRefinementChainIsDeterministic() {
+        let layout = GridLayout()
+        let controller = OverlayController(gridLayout: layout, screenBoundsProvider: { GridRect(x: 0, y: 0, width: 100, height: 100) })
+        controller.start()
+
+        _ = controller.handleKey("1")
+        _ = controller.handleKey("a")
+
+        XCTAssertEqual(controller.targetRect, GridRect(x: 0, y: 12.5, width: 1, height: 6.25))
+        XCTAssertEqual(controller.targetPoint, GridPoint(x: 0.5, y: 15.625))
+    }
+}


### PR DESCRIPTION
## Summary
- set up a Swift package with a reusable core module and executable entry point for the overlay
- scaffold input handling, grid refinement, overlay state, and zoom controller types per PLAN.md
- add Makefile shortcuts and initial tests for grid subdivision and refinement

## Testing
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928d81235a4832b8af33257915b1dd9)