### PR TITLE
Add CI workflows for tests and macOS binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: macos-15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Run test suite
+        run: swift test --parallel

--- a/.github/workflows/macos-binary.yml
+++ b/.github/workflows/macos-binary.yml
@@ -1,0 +1,27 @@
+name: macOS Binary
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build release binary
+    runs-on: macos-15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Build release artifact
+        run: swift build --configuration release
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: Asdfghjkl-macos-binary
+          path: .build/apple/Products/Release/Asdfghjkl
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ To keep the binary alive for a quick state-machine demo, run with `ASDFGHJKL_DEM
 ```sh
 ASDFGHJKL_DEMO=1 .build/debug/Asdfghjkl
 ```
+
+## Continuous integration
+
+GitHub Actions keep the package healthy and provide a downloadable binary:
+
+* `Test` runs on pushes to `main` and all pull requests, setting up Swift 6.2 on macOS and executing `swift test --parallel`.
+* `macOS Binary` is a manually triggered workflow that builds a release binary on macOS and uploads `.build/apple/Products/Release/Asdfghjkl` as an artifact.


### PR DESCRIPTION
## Summary
- add a macOS-based CI workflow that sets up Swift 6.2 and runs the test suite on pushes and pull requests
- provide a manual workflow to build a release binary on macOS and upload it as an artifact
- document the new workflows in the README for quick reference

## Testing
- swift test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928dbc73fc4832bb299b8c7cc440bbe)