### PR TITLE
Wire overlay callbacks and expand tests

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,14 @@
 
 Tiny swift app yhat lets the user use the keyboard to move and click the mouse.
 
+## Progress
+
+* ✅ Core grid refinement and overlay state machine are implemented (`GridLayout`, `OverlayState`, `OverlayController`).
+* ✅ Command double-tap recognition and input routing logic are in place (`CommandTapRecognizer`, `InputManager`).
+* ✅ Zoom controller tracks the active target rect so UI rendering can subscribe when the AppKit layer arrives.
+* 🟡 Action layer still needs real CGEvent click + cursor movement wiring (currently emits to an injected handler).
+* 🟡 Overlay windows, zoom UI, and global event taps remain to be hooked up for a full macOS experience.
+
 ## 0\. UX / Behaviour spec
 
 *   **Trigger:** double-tap `Cmd` anywhere in macOS.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Named after the Deadmau5' song Asdfghjkl, as the mouse is dead and you use a Qwe
 
 This repository currently contains a scaffolded macOS overlay app described in `PLAN.md`.
 The Swift Package builds a headless skeleton of the input, overlay, and action layers so we
-can iterate on the logic before attaching real AppKit windows and event taps.
+can iterate on the logic before attaching real AppKit windows and event taps. The overlay
+controller can now drive an injected click handler and keep a zoom controller in sync with
+the current target rectangle, making it easier to plug UI rendering into the existing state
+machine.
 
 ## Building and testing
 

--- a/Tests/AsdfghjklTests/CommandTapRecognizerTests.swift
+++ b/Tests/AsdfghjklTests/CommandTapRecognizerTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import AsdfghjklCore
+
+final class CommandTapRecognizerTests: XCTestCase {
+    func testDoubleTapTriggersCallback() {
+        var fired = false
+        var recognizer = CommandTapRecognizer()
+
+        recognizer.handleCommandDown()
+        recognizer.handleCommandUp { fired = true }
+
+        recognizer.handleCommandDown()
+        recognizer.handleCommandUp { fired = true }
+
+        XCTAssertTrue(fired)
+    }
+
+    func testUsingModifierCancelsDoubleTap() {
+        var fired = false
+        var recognizer = CommandTapRecognizer()
+
+        recognizer.handleCommandDown()
+        recognizer.handleCommandModifierUse()
+        recognizer.handleCommandUp { fired = true }
+
+        recognizer.handleCommandDown()
+        recognizer.handleCommandUp { fired = true }
+
+        XCTAssertFalse(fired)
+    }
+}

--- a/Tests/AsdfghjklTests/InputManagerTests.swift
+++ b/Tests/AsdfghjklTests/InputManagerTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import AsdfghjklCore
+
+final class InputManagerTests: XCTestCase {
+    func testDoubleTapActivatesOverlay() {
+        let controller = OverlayController()
+        let manager = InputManager(overlayController: controller)
+
+        manager.handleCommandDown()
+        manager.handleCommandUp()
+
+        manager.handleCommandDown()
+        manager.handleCommandUp()
+
+        XCTAssertTrue(controller.isActive)
+    }
+
+    func testModifierUsePreventsImmediateActivation() {
+        let controller = OverlayController()
+        let manager = InputManager(overlayController: controller)
+
+        manager.handleCommandDown()
+        manager.markCommandAsModifier()
+        manager.handleCommandUp()
+
+        manager.handleCommandDown()
+        manager.handleCommandUp()
+
+        XCTAssertFalse(controller.isActive)
+    }
+}

--- a/Tests/AsdfghjklTests/OverlayControllerTests.swift
+++ b/Tests/AsdfghjklTests/OverlayControllerTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import AsdfghjklCore
+
+final class OverlayControllerTests: XCTestCase {
+    func testStartResetsToScreenBounds() {
+        let expectedRect = GridRect(x: 10, y: 20, width: 300, height: 200)
+        let controller = OverlayController(screenBoundsProvider: { expectedRect })
+
+        controller.start()
+
+        XCTAssertTrue(controller.isActive)
+        XCTAssertEqual(controller.targetRect, expectedRect)
+    }
+
+    func testRefinementUpdatesZoomController() {
+        var updates: [GridRect] = []
+        let zoom = ZoomController(initialRect: .defaultScreen)
+        let controller = OverlayController(
+            gridLayout: GridLayout(),
+            screenBoundsProvider: { GridRect(x: 0, y: 0, width: 100, height: 100) },
+            zoomController: zoom
+        )
+
+        controller.start()
+        controller.handleKey("q")
+        updates.append(zoom.observedRect)
+
+        controller.handleKey("w")
+        updates.append(zoom.observedRect)
+
+        XCTAssertEqual(updates.count, 2)
+        XCTAssertEqual(updates[0], GridRect(x: 0, y: 25, width: 10, height: 25))
+        XCTAssertEqual(updates[1], GridRect(x: 1, y: 31.25, width: 1, height: 6.25))
+    }
+
+    func testClickDelegatesToHandlerAndDeactivates() {
+        var clickedPoint: GridPoint?
+        let controller = OverlayController(
+            gridLayout: GridLayout(),
+            screenBoundsProvider: { GridRect(x: 0, y: 0, width: 80, height: 40) },
+            clickHandler: { clickedPoint = $0 }
+        )
+
+        controller.start()
+        controller.handleKey("1")
+        controller.click()
+
+        XCTAssertFalse(controller.isActive)
+        XCTAssertEqual(clickedPoint, GridPoint(x: 4, y: 5))
+    }
+}


### PR DESCRIPTION
## Summary
- add click handling hook and zoom syncing to the overlay controller
- expand unit tests covering overlay behaviour, command tap recognition, and input routing
- document current progress and updated scaffolding details

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928dca85380832ba4509981178a13f6)