### PR TITLE
Improve command tap timing and tests

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -8,6 +8,7 @@ Tiny swift app yhat lets the user use the keyboard to move and click the mouse.
 * ✅ Command double-tap recognition and input routing logic are in place (`CommandTapRecognizer`, `InputManager`).
 * ✅ Zoom controller tracks the active target rect so UI rendering can subscribe when the AppKit layer arrives.
 * 🟢 Action layer posts real CGEvent cursor warp + click events on macOS via `SystemMouseActionPerformer`.
+* 🟡 CGEvent tap installation is still stubbed in `InputManager.start`; needs wiring once AppKit scaffolding lands.
 * 🟡 Overlay windows, zoom UI, and global event taps remain to be hooked up for a full macOS experience.
 
 ## 0\. UX / Behaviour spec

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use the keyboard instead of the mouse.
 
 Named after the Deadmau5' song Asdfghjkl, as the mouse is dead and you use a Qwerty keyboard instead.
 
-**Double tap Cmd to see an overlay on your screen. Tap a corresponding key to select that area. tap again (and again) to drill down. Tap soace to move the mouse and click.**
+**Double tap Cmd to see an overlay on your screen. Tap a corresponding key to select that area, then tap again (and again) to drill down. Tap space to move the mouse and click.**
 
 This repository currently contains a scaffolded macOS overlay app described in `PLAN.md`.
 The Swift Package builds a headless skeleton of the input, overlay, and action layers so we

--- a/Sources/AsdfghjklCore/CommandTapRecognizer.swift
+++ b/Sources/AsdfghjklCore/CommandTapRecognizer.swift
@@ -4,7 +4,13 @@ public struct CommandTapRecognizer {
     public private(set) var cmdDown: Bool = false
     public private(set) var cmdUsedAsModifierSinceDown: Bool = false
     private var cmdLastTapTime: Date?
-    public var doubleTapThreshold: TimeInterval = 0.35
+    public var doubleTapThreshold: TimeInterval
+    private let currentTime: () -> Date
+
+    public init(doubleTapThreshold: TimeInterval = 0.35, currentTime: @escaping () -> Date = Date.init) {
+        self.doubleTapThreshold = doubleTapThreshold
+        self.currentTime = currentTime
+    }
 
     public mutating func handleCommandDown() {
         cmdDown = true
@@ -26,7 +32,7 @@ public struct CommandTapRecognizer {
             return
         }
 
-        let now = Date()
+        let now = currentTime()
         if let last = cmdLastTapTime, now.timeIntervalSince(last) < doubleTapThreshold {
             onDoubleTap()
         }

--- a/Tests/AsdfghjklTests/CommandTapRecognizerTests.swift
+++ b/Tests/AsdfghjklTests/CommandTapRecognizerTests.swift
@@ -28,4 +28,46 @@ final class CommandTapRecognizerTests: XCTestCase {
 
         XCTAssertFalse(fired)
     }
+
+    func testDoubleTapHonoursThreshold() {
+        var timestamps: [Date] = [
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 0.2),
+            Date(timeIntervalSince1970: 1.0)
+        ]
+
+        var firedCount = 0
+        var recognizer = CommandTapRecognizer(currentTime: { timestamps.removeFirst() })
+
+        recognizer.handleCommandDown()
+        recognizer.handleCommandUp { firedCount += 1 }
+
+        recognizer.handleCommandDown()
+        recognizer.handleCommandUp { firedCount += 1 }
+
+        recognizer.handleCommandDown()
+        recognizer.handleCommandUp { firedCount += 1 }
+
+        XCTAssertEqual(firedCount, 1, "Only the second tap within the threshold should trigger")
+    }
+
+    func testModifierClearsPreviousTapRecord() {
+        var timestamps: [Date] = [
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 0.1),
+            Date(timeIntervalSince1970: 0.2)
+        ]
+
+        var fired = false
+        var recognizer = CommandTapRecognizer(currentTime: { timestamps.removeFirst() })
+
+        recognizer.handleCommandDown()
+        recognizer.handleCommandModifierUse()
+        recognizer.handleCommandUp { fired = true }
+
+        recognizer.handleCommandDown()
+        recognizer.handleCommandUp { fired = true }
+
+        XCTAssertFalse(fired, "Modifier use should clear the last tap and require a fresh pair of taps")
+    }
 }


### PR DESCRIPTION
## Summary
- make the command double-tap recognizer clock-injectable for deterministic behavior
- add coverage for threshold honoring and modifier-reset behavior in the recognizer tests
- refresh documentation for the keyboard overlay summary and note the remaining input tap work in PLAN.md

## Testing
- swift test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928e1cbfd28832bb8c8408ee0a59442)