### PR TITLE
Fix macOS binary artifact upload

### DIFF
--- a/.github/workflows/macos-binary.yml
+++ b/.github/workflows/macos-binary.yml
@@ -18,8 +18,14 @@ jobs:
 
       - name: Build release artifact
         run: |
-          BIN_PATH=$(swift build --configuration release --show-bin-path)
+          BIN_PATH=$(swift build --configuration release --product Asdfghjkl --show-bin-path)
           echo "BIN_PATH=$BIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Show build output
+        run: |
+          echo "BIN_PATH=$BIN_PATH"
+          ls -la "$BIN_PATH"
+          find "$BIN_PATH" -maxdepth 1 -type f -print
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ ASDFGHJKL_DEMO=1 .build/debug/Asdfghjkl
 GitHub Actions keep the package healthy and provide a downloadable binary:
 
 * `Test` runs on pushes to `main` and all pull requests, setting up Swift 6.2 on macOS and executing `swift test --parallel`.
-* `macOS Binary` is a manually triggered workflow that builds a release binary on macOS, records `swift build --configuration release --show-bin-path` in the environment, and uploads the resulting `Asdfghjkl` executable from that directory as an artifact.
+* `macOS Binary` is a manually triggered workflow that builds the `Asdfghjkl` release product on macOS, records `swift build --configuration release --product Asdfghjkl --show-bin-path` in the environment, lists the contents of the reported bin directory for debugging, and uploads the resulting executable as an artifact.


### PR DESCRIPTION
## Summary
- build the macOS release product explicitly and export its bin path
- log the bin directory contents for easier debugging of artifact uploads
- update the CI documentation to match the new workflow steps

## Testing
- swift test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928e23395bc832b9eda2f6f6c1cb807)