### PR TITLE
Add overlay keydown handling and tests

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -8,6 +8,7 @@ Tiny swift app yhat lets the user use the keyboard to move and click the mouse.
 * ✅ Command double-tap recognition and input routing logic are in place (`CommandTapRecognizer`, `InputManager`).
 * ✅ Zoom controller tracks the active target rect so UI rendering can subscribe when the AppKit layer arrives.
 * 🟢 Action layer posts real CGEvent cursor warp + click events on macOS via `SystemMouseActionPerformer`.
+* 🟢 InputManager consumes overlay key events (grid refinement, space-to-click, escape-to-cancel) and marks Command-as-modifier usage while we wait for CGEvent taps.
 * 🟡 CGEvent tap installation is still stubbed in `InputManager.start`; needs wiring once AppKit scaffolding lands.
 * 🟡 Overlay windows, zoom UI, and global event taps remain to be hooked up for a full macOS experience.
 

--- a/Sources/AsdfghjklCore/InputManager.swift
+++ b/Sources/AsdfghjklCore/InputManager.swift
@@ -44,4 +44,30 @@ public final class InputManager {
     public func cancelOverlay() {
         overlayController.cancel()
     }
+
+    /// Handles a key down event, performing refinement and click/cancel commands when the overlay is active.
+    /// - Parameters:
+    ///   - key: The pressed character.
+    ///   - commandActive: Whether the Command modifier is currently held down.
+    /// - Returns: `true` if the event was consumed by the overlay controller, `false` otherwise.
+    @discardableResult
+    public func handleKeyDown(_ key: Character, commandActive: Bool = false) -> Bool {
+        if commandActive {
+            markCommandAsModifier()
+        }
+
+        guard overlayController.isActive else { return false }
+
+        if key == "\u{1b}" { // Escape
+            cancelOverlay()
+            return true
+        }
+
+        if key == " " { // Space
+            handleSpacebarClick()
+            return true
+        }
+
+        return handleKeyPress(key) != nil
+    }
 }

--- a/Tests/AsdfghjklTests/InputManagerTests.swift
+++ b/Tests/AsdfghjklTests/InputManagerTests.swift
@@ -28,4 +28,66 @@ final class InputManagerTests: XCTestCase {
 
         XCTAssertFalse(controller.isActive)
     }
+
+    func testOverlayHandlesGridRefinementWhenActive() {
+        let controller = OverlayController(screenBoundsProvider: { GridRect(x: 0, y: 0, width: 100, height: 100) })
+        let manager = InputManager(overlayController: controller)
+
+        controller.start()
+        let consumed = manager.handleKeyDown("1")
+
+        XCTAssertTrue(consumed)
+        XCTAssertEqual(controller.targetRect, GridRect(x: 0, y: 0, width: 10, height: 25))
+    }
+
+    func testSpacebarClickConsumesEventAndDeactivatesOverlay() {
+        let performer = StubMouseActionPerformer()
+        let controller = OverlayController(
+            screenBoundsProvider: { GridRect(x: 0, y: 0, width: 40, height: 20) },
+            mouseActionPerformer: performer
+        )
+        let manager = InputManager(overlayController: controller)
+
+        controller.start()
+        controller.handleKey("0")
+
+        let consumed = manager.handleKeyDown(" ")
+
+        XCTAssertTrue(consumed)
+        XCTAssertFalse(controller.isActive)
+        XCTAssertEqual(performer.receivedPoint, GridPoint(x: 38, y: 2.5))
+    }
+
+    func testEscapeCancelsOverlay() {
+        let controller = OverlayController()
+        let manager = InputManager(overlayController: controller)
+
+        controller.start()
+        let consumed = manager.handleKeyDown("\u{1b}")
+
+        XCTAssertTrue(consumed)
+        XCTAssertFalse(controller.isActive)
+    }
+
+    func testCommandHeldMarksModifierUse() {
+        let controller = OverlayController()
+        let manager = InputManager(overlayController: controller)
+
+        manager.handleCommandDown()
+        _ = manager.handleKeyDown("c", commandActive: true)
+        manager.handleCommandUp()
+
+        manager.handleCommandDown()
+        manager.handleCommandUp()
+
+        XCTAssertFalse(controller.isActive, "Command+key use should suppress double-tap activation")
+    }
+}
+
+private final class StubMouseActionPerformer: MouseActionPerforming {
+    private(set) var receivedPoint: GridPoint?
+
+    func moveAndClick(at point: GridPoint) {
+        receivedPoint = point
+    }
 }


### PR DESCRIPTION
## Summary
- add a high-level `handleKeyDown` helper so `InputManager` can consume overlay key events and mark Command modifier use
- cover refinement, space-to-click, escape-to-cancel, and modifier detection with new `InputManager` unit tests
- update PLAN progress to reflect the new input handling coverage

## Testing
- swift test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928e338f164832b919432ba7acec4cd)