### PR TITLE
Fix macOS binary workflow build

### DIFF
--- a/.github/workflows/macos-binary.yml
+++ b/.github/workflows/macos-binary.yml
@@ -18,7 +18,8 @@ jobs:
 
       - name: Build release artifact
         run: |
-          BIN_PATH=$(swift build --configuration release --product Asdfghjkl --show-bin-path)
+          swift build --configuration release --product Asdfghjkl
+          BIN_PATH=$(swift build --configuration release --show-bin-path)
           echo "BIN_PATH=$BIN_PATH" >> "$GITHUB_ENV"
 
       - name: Show build output

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ ASDFGHJKL_DEMO=1 .build/debug/Asdfghjkl
 GitHub Actions keep the package healthy and provide a downloadable binary:
 
 * `Test` runs on pushes to `main` and all pull requests, setting up Swift 6.2 on macOS and executing `swift test --parallel`.
-* `macOS Binary` is a manually triggered workflow that builds the `Asdfghjkl` release product on macOS, records `swift build --configuration release --product Asdfghjkl --show-bin-path` in the environment, lists the contents of the reported bin directory for debugging, and uploads the resulting executable as an artifact.
+* `macOS Binary` is a manually triggered workflow that builds the `Asdfghjkl` release product on macOS, captures the release bin path with `swift build --configuration release --show-bin-path`, lists the contents of that directory for debugging, and uploads the resulting executable as an artifact.


### PR DESCRIPTION
## Summary
- run an actual release build in the macOS binary workflow before capturing the bin path
- simplify the bin path capture to rely on swift's release show-bin-path output
- document the updated macOS binary workflow steps in the README

## Testing
- swift test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928e478c338832b8804897b74691e83)