### PR TITLE
Add zoom snapshot support and tests

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,14 +2,14 @@
 
 Tiny swift app yhat lets the user use the keyboard to move and click the mouse.
 
-## Progress [80% done]
+## Progress [85% done]
 
 * ✅ Core grid refinement and overlay state machine are implemented (`GridLayout`, `OverlayState`, `OverlayController`).
 * ✅ Command double-tap recognition and input routing logic are in place (`CommandTapRecognizer`, `InputManager`).
 * ✅ Zoom controller tracks the active target rect so UI rendering can subscribe when the AppKit layer arrives.
 * 🟢 Action layer posts real CGEvent cursor warp + click events on macOS via `SystemMouseActionPerformer`.
-* 🟢 InputManager consumes overlay key events (grid refinement, space-to-click, escape-to-cancel) and marks Command-as-modifier usage while we wait for CGEvent taps.
-* 🟡 CGEvent tap installation is still stubbed in `InputManager.start`; needs wiring once AppKit scaffolding lands.
+* 🟢 InputManager consumes overlay key events (grid refinement, space-to-click, escape-to-cancel) and marks Command-as-modifier usage to avoid false triggers.
+* 🟢 CGEvent tap installation now lives in `InputManager.start`, consuming overlay key events and toggling on double Cmd.
 * 🟡 Overlay windows, zoom UI, and global event taps remain to be hooked up for a full macOS experience.
 
 ## 0\. UX / Behaviour spec [100% done]
@@ -341,6 +341,7 @@ Now you’ve got the core “magic”: double-tap Cmd, type a few keys, Space to
 
 *   Add a small zoom window that listens to `currentRect` and renders a magnified snapshot.
 *   Tune performance and maybe cap refresh to “on keypress only”.
+    *   **Status:** The zoom window subscribes to `ZoomController` and captures a live display snapshot (requires Screen Recording permission on macOS).
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Named after the Deadmau5' song Asdfghjkl, as the mouse is dead and you use a Qwe
 The package now ships a SwiftUI/AppKit macOS app lifecycle that installs a global CGEvent tap
 to capture double-Cmd activation and routes key presses into the `InputManager`. Borderless
 overlay windows span each connected `NSScreen` to visualise the grid refinement and
-highlight the current target, and a floating zoom window follows
-`ZoomController.observedRect`. Key presses are consumed while the overlay is active: letters
-refine the grid, `Space` clicks, and `Esc` cancels.
+highlight the current target. A floating zoom window now captures a live snapshot of the
+active region (when Screen Recording permission is granted) so you can see exactly where a
+click will land as you refine the grid. Key presses are consumed while the overlay is
+active: letters refine the grid, `Space` clicks, and `Esc` cancels.
 
 ## Building and testing
 

--- a/Sources/Asdfghjkl/App.swift
+++ b/Sources/Asdfghjkl/App.swift
@@ -25,7 +25,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var activeScreenRect: GridRect = .defaultScreen
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        zoomController = ZoomController(initialRect: .defaultScreen)
+        let snapshotProvider = CGWindowListSnapshotProvider()
+        zoomController = ZoomController(initialRect: .defaultScreen, snapshotProvider: snapshotProvider)
         overlayController = OverlayController(
             gridLayout: gridLayout,
             screenBoundsProvider: { [weak self] in

--- a/Sources/Asdfghjkl/OverlayViews.swift
+++ b/Sources/Asdfghjkl/OverlayViews.swift
@@ -76,19 +76,34 @@ struct ZoomPreviewView: View {
             Text("Zoom preview")
                 .font(.headline)
             GeometryReader { proxy in
-                let rect = zoomController.observedRect
-                RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(Color.accentColor, lineWidth: 2)
-                    .background(
+                ZStack {
+                    if let snapshot = zoomController.latestSnapshot {
+                        Image(decorative: snapshot, scale: 1.0)
+                            .resizable()
+                            .scaledToFit()
+                    } else {
                         RoundedRectangle(cornerRadius: 8)
                             .fill(Color.accentColor.opacity(0.08))
-                    )
-                    .overlay(alignment: .topLeading) {
-                        Text("\(Int(rect.width)) × \(Int(rect.height))")
-                            .font(.caption)
-                            .padding(6)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .strokeBorder(Color.accentColor, lineWidth: 2)
+                            )
+                            .overlay(alignment: .center) {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
                     }
-                    .padding(.vertical, 4)
+                }
+                .overlay(alignment: .topLeading) {
+                    let rect = zoomController.observedRect
+                    Text("\(Int(rect.width)) × \(Int(rect.height))")
+                        .font(.caption)
+                        .padding(6)
+                        .background(.thinMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                        .padding(6)
+                }
+                .padding(.vertical, 4)
             }
             .frame(height: 120)
             .clipShape(RoundedRectangle(cornerRadius: 10))

--- a/Sources/AsdfghjklCore/ZoomController.swift
+++ b/Sources/AsdfghjklCore/ZoomController.swift
@@ -5,19 +5,51 @@ import Combine
 public protocol ObservableObject {}
 #endif
 
+#if os(macOS)
+import CoreGraphics
+
+public protocol ZoomSnapshotProviding {
+    func capture(rect: GridRect) -> CGImage?
+}
+
+public struct CGWindowListSnapshotProvider: ZoomSnapshotProviding {
+    public init() {}
+
+    public func capture(rect: GridRect) -> CGImage? {
+        let cgRect = CGRect(x: rect.origin.x, y: rect.origin.y, width: rect.size.x, height: rect.size.y)
+        return CGWindowListCreateImage(cgRect, .optionOnScreenOnly, kCGNullWindowID, [.bestResolution, .boundsIgnoreFraming])
+    }
+}
+#endif
+
 public final class ZoomController: ObservableObject {
     #if canImport(Combine)
     @Published public private(set) var observedRect: GridRect
+    #if os(macOS)
+    @Published public private(set) var latestSnapshot: CGImage?
+    #endif
     #else
     public private(set) var observedRect: GridRect
     #endif
 
+    #if os(macOS)
+    private let snapshotProvider: ZoomSnapshotProviding?
+
+    public init(initialRect: GridRect = .defaultScreen, snapshotProvider: ZoomSnapshotProviding? = nil) {
+        self.observedRect = initialRect
+        self.snapshotProvider = snapshotProvider
+    }
+    #else
     public init(initialRect: GridRect = .defaultScreen) {
         self.observedRect = initialRect
     }
+    #endif
 
     public func update(rect: GridRect) {
         observedRect = rect
-        // TODO: Render a magnified snapshot of the rect once hooked into AppKit.
+
+        #if os(macOS)
+        latestSnapshot = snapshotProvider?.capture(rect: rect)
+        #endif
     }
 }

--- a/Tests/AsdfghjklTests/ZoomControllerTests.swift
+++ b/Tests/AsdfghjklTests/ZoomControllerTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import AsdfghjklCore
+
+final class ZoomControllerTests: XCTestCase {
+    func testObservedRectUpdatesOnRefinement() {
+        let controller = ZoomController(initialRect: GridRect(x: 0, y: 0, width: 100, height: 100))
+
+        controller.update(rect: GridRect(x: 10, y: 20, width: 30, height: 40))
+
+        XCTAssertEqual(controller.observedRect, GridRect(x: 10, y: 20, width: 30, height: 40))
+    }
+
+    #if os(macOS)
+    func testSnapshotProviderInvokedWhenPresent() {
+        let provider = StubSnapshotProvider()
+        let controller = ZoomController(initialRect: GridRect(x: 0, y: 0, width: 50, height: 50), snapshotProvider: provider)
+
+        let rect = GridRect(x: 5, y: 6, width: 10, height: 12)
+        controller.update(rect: rect)
+
+        XCTAssertEqual(provider.requestedRect, rect)
+        XCTAssertNotNil(controller.latestSnapshot)
+    }
+    #endif
+}
+
+#if os(macOS)
+private final class StubSnapshotProvider: ZoomSnapshotProviding {
+    private let image: CGImage
+    private(set) var requestedRect: GridRect?
+
+    init() {
+        let colorSpace = CGColorSpaceCreateDeviceGray()
+        let context = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 1,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        )
+        self.image = context!.makeImage()!
+    }
+
+    func capture(rect: GridRect) -> CGImage? {
+        requestedRect = rect
+        return image
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a CoreGraphics-backed snapshot provider so the zoom window can display a live preview of the active target
- wire the macOS app delegate and SwiftUI preview to use the captured snapshots with a graceful placeholder
- document the updated plan progress and cover ZoomController updates with new tests

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928e72fade4832b806d12a97e2d4e95)