### PR TITLE
Reset overlay state on deactivate and refresh plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,7 @@
 
 Tiny swift app yhat lets the user use the keyboard to move and click the mouse.
 
-## Progress [95% done]
+## Progress [80% done]
 
 * ✅ Core grid refinement and overlay state machine are implemented (`GridLayout`, `OverlayState`, `OverlayController`).
 * ✅ Command double-tap recognition and input routing logic are in place (`CommandTapRecognizer`, `InputManager`).
@@ -11,6 +11,9 @@ Tiny swift app yhat lets the user use the keyboard to move and click the mouse.
 * 🟢 InputManager consumes overlay key events (grid refinement, space-to-click, escape-to-cancel) and marks Command-as-modifier usage to avoid false triggers.
 * 🟢 CGEvent tap installation now lives in `InputManager.start`, consuming overlay key events and toggling on double Cmd.
 * ✅ Overlay windows, zoom UI, and global event taps are now wired into the macOS app lifecycle (auto-rebuild on screen changes).
+* 🔶 Permissions and error handling are thin: when CGEvent taps fail we only `print` to stdout; add user-facing prompts and retry/diagnostic UI for missing Input Monitoring + Accessibility rights.
+* 🔶 Screen reconfiguration while the overlay is active leaves the grid locked to the old screen bounds; cancel or re-seed the state when notifications arrive so refinements stay on-screen.
+* 🔶 Zoom window lifecycle is currently tied to overlay visibility only; consider a “keep warm” option or throttled refresh to avoid slow snapshotting when rapidly re-activating the overlay.
 
 ## 0\. UX / Behaviour spec [100% done]
 

--- a/Sources/AsdfghjklCore/OverlayController.swift
+++ b/Sources/AsdfghjklCore/OverlayController.swift
@@ -39,8 +39,7 @@ public final class OverlayController {
     }
 
     public func cancel() {
-        state.isActive = false
-        notifyStateChange()
+        deactivate()
     }
 
     @discardableResult
@@ -57,11 +56,16 @@ public final class OverlayController {
         guard state.isActive else { return }
         let target = state.targetPoint
         mouseActionPerformer.moveAndClick(at: target)
-        state.isActive = false
-        notifyStateChange()
+        deactivate()
     }
 
     private func notifyStateChange() {
         stateDidChange?(state)
+    }
+
+    private func deactivate() {
+        guard state.isActive else { return }
+        state.reset(rect: state.rootRect)
+        notifyStateChange()
     }
 }

--- a/Tests/AsdfghjklTests/OverlayControllerTests.swift
+++ b/Tests/AsdfghjklTests/OverlayControllerTests.swift
@@ -47,6 +47,7 @@ final class OverlayControllerTests: XCTestCase {
 
         XCTAssertFalse(controller.isActive)
         XCTAssertEqual(performer.receivedPoint, GridPoint(x: 4, y: 5))
+        XCTAssertEqual(controller.targetRect, GridRect(x: 0, y: 0, width: 80, height: 40))
     }
 
     func testClickIgnoredWhenInactive() {
@@ -75,6 +76,24 @@ final class OverlayControllerTests: XCTestCase {
         controller.start()
 
         XCTAssertEqual(controller.targetRect, bounds[1])
+    }
+
+    func testCancelResetsRectAndNotifiesListeners() {
+        let bounds = GridRect(x: 10, y: 20, width: 300, height: 200)
+        let controller = OverlayController(screenBoundsProvider: { bounds })
+
+        var observedStates: [OverlayState] = []
+        controller.stateDidChange = { state in
+            observedStates.append(state)
+        }
+
+        controller.start()
+        controller.handleKey("q")
+        controller.cancel()
+
+        XCTAssertEqual(observedStates.count, 3, "start, refinement, and cancel should all notify listeners")
+        XCTAssertEqual(observedStates.last?.currentRect, bounds)
+        XCTAssertFalse(observedStates.last?.isActive ?? true)
     }
 }
 


### PR DESCRIPTION
## Summary
- reset overlay state to the root bounds when deactivating after clicks or cancels and continue notifying listeners
- expand overlay controller test coverage for deactivation behaviour
- refresh PLAN progress to capture remaining permission, screen-change, and zoom lifecycle gaps

## Testing
- swift test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928ea0f6fa0832bb86e3cf6f42d7316)