### PR TITLE
Finish zoom snapshot and positioning

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -32,6 +32,7 @@ Tiny swift app yhat lets the user use the keyboard to move and click the mouse.
     *   After N keypresses, you’ve got a tiny region; `Space` clicks centre of that region.
 *   **Zoom:**
     *   A small floating zoom window that shows a magnified preview of the current region (like a loupe).
+    *   Keep the zoom window near the active target/cursor instead of the screen centre, clamped to the visible frame.
 *   **Multi-display:**
     *   Overlay appears on _all_ displays.
     *   Each keypress refines the region _within the currently selected display_.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ to capture double-Cmd activation and routes key presses into the `InputManager`.
 overlay windows span each connected `NSScreen` to visualise the grid refinement and
 highlight the current target. A floating zoom window now captures a live snapshot of the
 active region (when Screen Recording permission is granted) so you can see exactly where a
-click will land as you refine the grid. Key presses are consumed while the overlay is
+click will land as you refine the grid. The zoom window follows the target region so it
+stays close to your focus point without drifting off-screen. Key presses are consumed while the overlay is
 active: letters refine the grid, `Space` clicks, and `Esc` cancels.
 
 The macOS app installs the global CGEvent tap on launch (requires Input Monitoring and

--- a/Sources/Asdfghjkl/ZoomWindowController.swift
+++ b/Sources/Asdfghjkl/ZoomWindowController.swift
@@ -2,14 +2,25 @@ import Foundation
 #if os(macOS)
 import SwiftUI
 import AppKit
+import Combine
 import AsdfghjklCore
 
 final class ZoomWindowController {
     private let zoomController: ZoomController
     private var window: NSWindow?
+    private var cancellable: AnyCancellable?
+    private var latestRect: GridRect
+    private let defaultWindowSize = NSSize(width: 240, height: 180)
 
     init(zoomController: ZoomController) {
         self.zoomController = zoomController
+        self.latestRect = zoomController.observedRect
+        cancellable = zoomController.$observedRect
+            .receive(on: RunLoop.main)
+            .sink { [weak self] rect in
+                self?.latestRect = rect
+                self?.positionWindow(for: rect)
+            }
     }
 
     func show() {
@@ -17,6 +28,7 @@ final class ZoomWindowController {
             window = makeWindow()
         }
         window?.orderFrontRegardless()
+        positionWindow(for: latestRect)
     }
 
     func hide() {
@@ -32,9 +44,35 @@ final class ZoomWindowController {
         window.backgroundColor = NSColor.clear
         window.hasShadow = true
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        window.setContentSize(NSSize(width: 240, height: 180))
-        window.center()
+        window.setContentSize(defaultWindowSize)
         return window
+    }
+
+    private func positionWindow(for rect: GridRect) {
+        guard let window else { return }
+        let targetPoint = GridPoint(x: rect.midX, y: rect.midY)
+
+        guard let screen = screen(containing: targetPoint) else { return }
+        let visibleFrame = screen.visibleFrame
+        let bounds = GridRect(
+            x: visibleFrame.origin.x,
+            y: visibleFrame.origin.y,
+            width: visibleFrame.width,
+            height: visibleFrame.height
+        )
+
+        let origin = ZoomWindowPositioner.clampedOrigin(
+            target: targetPoint,
+            windowSize: GridPoint(x: window.frame.width, y: window.frame.height),
+            bounds: bounds
+        )
+
+        window.setFrameOrigin(NSPoint(x: origin.x, y: origin.y))
+    }
+
+    private func screen(containing point: GridPoint) -> NSScreen? {
+        let cocoaPoint = NSPoint(x: point.x, y: point.y)
+        return NSScreen.screens.first { NSMouseInRect(cocoaPoint, $0.frame, false) } ?? NSScreen.main
     }
 }
 #endif

--- a/Sources/AsdfghjklCore/ZoomController.swift
+++ b/Sources/AsdfghjklCore/ZoomController.swift
@@ -33,11 +33,11 @@ public final class ZoomController: ObservableObject {
     #endif
 
     #if os(macOS)
-    private let snapshotProvider: ZoomSnapshotProviding?
+    private let snapshotProvider: ZoomSnapshotProviding
 
     public init(initialRect: GridRect = .defaultScreen, snapshotProvider: ZoomSnapshotProviding? = nil) {
         self.observedRect = initialRect
-        self.snapshotProvider = snapshotProvider
+        self.snapshotProvider = snapshotProvider ?? CGWindowListSnapshotProvider()
     }
     #else
     public init(initialRect: GridRect = .defaultScreen) {
@@ -49,7 +49,7 @@ public final class ZoomController: ObservableObject {
         observedRect = rect
 
         #if os(macOS)
-        latestSnapshot = snapshotProvider?.capture(rect: rect)
+        latestSnapshot = snapshotProvider.capture(rect: rect)
         #endif
     }
 }

--- a/Sources/AsdfghjklCore/ZoomWindowPositioner.swift
+++ b/Sources/AsdfghjklCore/ZoomWindowPositioner.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum ZoomWindowPositioner {
+    public static func clampedOrigin(
+        target: GridPoint,
+        windowSize: GridPoint,
+        bounds: GridRect,
+        padding: Double = 8
+    ) -> GridPoint {
+        let halfWidth = windowSize.x / 2
+        let halfHeight = windowSize.y / 2
+
+        let desiredX = target.x - halfWidth
+        let desiredY = target.y - halfHeight
+
+        let minX = bounds.minX + padding
+        let minY = bounds.minY + padding
+        let maxX = bounds.minX + bounds.width - windowSize.x - padding
+        let maxY = bounds.minY + bounds.height - windowSize.y - padding
+
+        let clampedX = max(minX, min(desiredX, maxX))
+        let clampedY = max(minY, min(desiredY, maxY))
+
+        return GridPoint(x: clampedX, y: clampedY)
+    }
+}

--- a/Tests/AsdfghjklTests/ZoomWindowPositionerTests.swift
+++ b/Tests/AsdfghjklTests/ZoomWindowPositionerTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import AsdfghjklCore
+
+final class ZoomWindowPositionerTests: XCTestCase {
+    func testOriginCentersAroundTarget() {
+        let bounds = GridRect(x: 0, y: 0, width: 300, height: 300)
+        let origin = ZoomWindowPositioner.clampedOrigin(
+            target: GridPoint(x: 150, y: 150),
+            windowSize: GridPoint(x: 100, y: 100),
+            bounds: bounds,
+            padding: 0
+        )
+
+        XCTAssertEqual(origin, GridPoint(x: 100, y: 100))
+    }
+
+    func testOriginClampsNearEdges() {
+        let bounds = GridRect(x: 0, y: 0, width: 200, height: 200)
+        let origin = ZoomWindowPositioner.clampedOrigin(
+            target: GridPoint(x: 10, y: 10),
+            windowSize: GridPoint(x: 80, y: 80),
+            bounds: bounds,
+            padding: 10
+        )
+
+        XCTAssertEqual(origin, GridPoint(x: 10, y: 10))
+    }
+
+    func testOriginClampsOnFarEdge() {
+        let bounds = GridRect(x: 0, y: 0, width: 200, height: 200)
+        let origin = ZoomWindowPositioner.clampedOrigin(
+            target: GridPoint(x: 190, y: 190),
+            windowSize: GridPoint(x: 80, y: 80),
+            bounds: bounds,
+            padding: 10
+        )
+
+        XCTAssertEqual(origin, GridPoint(x: 110, y: 110))
+    }
+}


### PR DESCRIPTION
## Summary
- capture zoom snapshots from the current target rect using CGWindowListCreateImage
- reposition the floating zoom window near the target with on-screen clamping
- document zoom positioning expectations and add geometry unit tests

## Testing
- swift test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692953a58134832b914d2713472fc6bd)