### PR TITLE
Add translucent grid labels to overlay

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -26,6 +26,7 @@ Tiny swift app yhat lets the user use the keyboard to move and click the mouse.
 *   **Grid:**
     *   4 rows × 10 columns (40 tiles).
     *   Layout roughly matches a QWERTY-ish mental model, but doesn’t have to be perfect.
+    *   Each grid cell visibly shows its corresponding key label with a translucent fill so users can map keys to tiles at a glance.
 *   **Refinement:**
     *   Start with full screen(s) area.
     *   Each key press slices into that area using the 4×10 grid.
@@ -142,7 +143,7 @@ Each window hosts a SwiftUI view that draws:
 
 *   lightly tinted rectangles for the grid cells
 *   the currently-selected tile highlighted
-*   optionally the label (letter) in each tile.
+*   the label (letter) in each tile; labels are required and should remain partially transparent to keep underlying content visible.
 
 You then have one “active display” (start with `NSScreen.main`) and simply ignore keyboard grid updates for other screens initially.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Named after the Deadmau5' song Asdfghjkl, as the mouse is dead and you use a Qwe
 The package now ships a SwiftUI/AppKit macOS app lifecycle that installs a global CGEvent tap
 to capture double-Cmd activation and routes key presses into the `InputManager`. Borderless
 overlay windows span each connected `NSScreen` to visualise the grid refinement and
-highlight the current target. A floating zoom window now captures a live snapshot of the
+highlight the current target. Each grid cell is labelled with its keyboard key using a translucent fill so you can map inputs to tiles without obscuring the screen. A floating zoom window now captures a live snapshot of the
 active region (when Screen Recording permission is granted) so you can see exactly where a
 click will land as you refine the grid. The zoom window follows the target region so it
 stays close to your focus point without drifting off-screen. Key presses are consumed while the overlay is

--- a/Sources/Asdfghjkl/OverlayViews.swift
+++ b/Sources/Asdfghjkl/OverlayViews.swift
@@ -13,6 +13,7 @@ struct OverlayGridView: View {
             ZStack(alignment: .topLeading) {
                 Color.black.opacity(model.isActive ? 0.15 : 0)
                 gridLines(in: proxy.size)
+                gridLabels(in: proxy.size)
 
                 if let rect = highlightRect(in: proxy.size) {
                     RoundedRectangle(cornerRadius: 6)
@@ -50,6 +51,28 @@ struct OverlayGridView: View {
             }
         }
         .stroke(Color.white.opacity(0.35), lineWidth: 1)
+    }
+
+    private func gridLabels(in size: CGSize) -> some View {
+        let columnCount = max(1, gridLayout.columns)
+        let rowCount = max(1, gridLayout.rows)
+        let tileWidth = size.width / CGFloat(columnCount)
+        let tileHeight = size.height / CGFloat(rowCount)
+
+        return ForEach(0..<rowCount, id: \.self) { row in
+            ForEach(0..<columnCount, id: \.self) { column in
+                if let label = gridLayout.label(forRow: row, column: column) {
+                    let displayLabel = String(label).uppercased()
+
+                    Text(displayLabel)
+                        .font(.system(size: 22, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.75))
+                        .frame(width: tileWidth, height: tileHeight)
+                        .background(Color.black.opacity(0.1))
+                        .position(x: tileWidth * (CGFloat(column) + 0.5), y: tileHeight * (CGFloat(row) + 0.5))
+                }
+            }
+        }
     }
 
     private func highlightRect(in size: CGSize) -> CGRect? {

--- a/Sources/AsdfghjklCore/GridLayout.swift
+++ b/Sources/AsdfghjklCore/GridLayout.swift
@@ -39,7 +39,7 @@ public struct GridRect: Equatable {
     }
 }
 
-public struct GridCoordinate: Equatable {
+public struct GridCoordinate: Hashable, Equatable {
     public let row: Int
     public let column: Int
 }
@@ -48,11 +48,13 @@ public struct GridLayout {
     public let rows: Int
     public let columns: Int
     public let keymap: [Character: GridCoordinate]
+    private let coordinateToKey: [GridCoordinate: Character]
 
     public init(rows: Int = 4, columns: Int = 10, keymap: [Character: GridCoordinate] = GridLayout.defaultKeymap) {
         self.rows = rows
         self.columns = columns
         self.keymap = keymap
+        self.coordinateToKey = GridLayout.inverseKeymap(keymap)
     }
 
     public func coordinate(for key: Character) -> GridCoordinate? {
@@ -62,6 +64,11 @@ public struct GridLayout {
     public func rect(for key: Character, in rect: GridRect) -> GridRect? {
         guard let coordinate = coordinate(for: key) else { return nil }
         return rect.subdividing(rows: rows, columns: columns, row: coordinate.row, column: coordinate.column)
+    }
+
+    public func label(forRow row: Int, column: Int) -> Character? {
+        guard row >= 0, column >= 0, row < rows, column < columns else { return nil }
+        return coordinateToKey[GridCoordinate(row: row, column: column)]
     }
 
     public static var defaultKeymap: [Character: GridCoordinate] {
@@ -79,6 +86,16 @@ public struct GridLayout {
             }
         }
 
+        return mapping
+    }
+
+    private static func inverseKeymap(_ keymap: [Character: GridCoordinate]) -> [GridCoordinate: Character] {
+        var mapping: [GridCoordinate: Character] = [:]
+        for (key, coordinate) in keymap {
+            if mapping[coordinate] == nil {
+                mapping[coordinate] = key
+            }
+        }
         return mapping
     }
 }

--- a/Tests/AsdfghjklTests/GridLayoutTests.swift
+++ b/Tests/AsdfghjklTests/GridLayoutTests.swift
@@ -31,4 +31,16 @@ final class GridLayoutTests: XCTestCase {
         XCTAssertEqual(controller.targetRect, GridRect(x: 0, y: 12.5, width: 1, height: 6.25))
         XCTAssertEqual(controller.targetPoint, GridPoint(x: 0.5, y: 15.625))
     }
+
+    func testLabelsExposeKeyForEachCoordinate() {
+        let layout = GridLayout()
+
+        XCTAssertEqual(layout.label(forRow: 0, column: 0), Character("1"))
+        XCTAssertEqual(layout.label(forRow: 1, column: 1), Character("w"))
+        XCTAssertEqual(layout.label(forRow: 3, column: 9), Character("/"))
+
+        XCTAssertNil(layout.label(forRow: -1, column: 0))
+        XCTAssertNil(layout.label(forRow: 0, column: 20))
+        XCTAssertNil(layout.label(forRow: 4, column: 0))
+    }
 }


### PR DESCRIPTION
## Summary
- render keyboard labels in each grid cell with translucent fills in the overlay
- expose grid label lookup helpers with new tests
- update the plan and README to require and document visible grid labels

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929576d3ebc832b81113036e96acae8)