### PR TITLE
Fix overlay highlight orientation and enlarge zoom preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Named after the Deadmau5' song Asdfghjkl, as the mouse is dead and you use a Qwe
 The package now ships a SwiftUI/AppKit macOS app lifecycle that installs a global CGEvent tap
 to capture double-Cmd activation and routes key presses into the `InputManager`. Borderless
 overlay windows span each connected `NSScreen` to visualise the grid refinement and
-highlight the current target. Each grid cell is labelled with its keyboard key using a translucent fill so you can map inputs to tiles without obscuring the screen. A floating zoom window now captures a live snapshot of the
+highlight the current target. Grid rows follow the keyboard layout from top to bottom so the
+highlight tracks the expected key column and row. Each grid cell is labelled with its keyboard key using a translucent fill so you can map inputs to tiles without obscuring the screen. A floating zoom window now captures a live snapshot of the
 active region (when Screen Recording permission is granted) so you can see exactly where a
 click will land as you refine the grid. The zoom window follows the target region so it
-stays close to your focus point without drifting off-screen. Key presses are consumed while the overlay is
+stays close to your focus point without drifting off-screen and uses a larger preview so the
+destination is easy to verify. Key presses are consumed while the overlay is
 active: letters refine the grid, `Space` clicks, and `Esc` cancels.
 
 On multi-display setups, the 4×10 grid is divided horizontally across all overlay windows so

--- a/Sources/Asdfghjkl/OverlayViews.swift
+++ b/Sources/Asdfghjkl/OverlayViews.swift
@@ -83,11 +83,10 @@ struct OverlayGridView: View {
 
         let normalizedX = (intersection.minX - screenFrame.minX) / screenFrame.width * size.width
         let normalizedWidth = intersection.width / screenFrame.width * size.width
-        let normalizedYFromBottom = (intersection.minY - screenFrame.minY) / screenFrame.height * size.height
+        let normalizedY = (intersection.minY - screenFrame.minY) / screenFrame.height * size.height
         let normalizedHeight = intersection.height / screenFrame.height * size.height
-        let convertedY = size.height - normalizedYFromBottom - normalizedHeight
 
-        return CGRect(x: normalizedX, y: convertedY, width: normalizedWidth, height: normalizedHeight)
+        return CGRect(x: normalizedX, y: normalizedY, width: normalizedWidth, height: normalizedHeight)
     }
 }
 
@@ -126,9 +125,9 @@ struct ZoomPreviewView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                         .padding(6)
                 }
-                .padding(.vertical, 4)
+                .padding(.vertical, 6)
             }
-            .frame(height: 120)
+            .frame(height: 220)
             .clipShape(RoundedRectangle(cornerRadius: 10))
 
             let rect = zoomController.observedRect
@@ -140,7 +139,7 @@ struct ZoomPreviewView: View {
             .foregroundStyle(.secondary)
         }
         .padding(16)
-        .frame(width: 240)
+        .frame(width: 360)
     }
 }
 #endif

--- a/Sources/Asdfghjkl/ZoomWindowController.swift
+++ b/Sources/Asdfghjkl/ZoomWindowController.swift
@@ -11,7 +11,7 @@ final class ZoomWindowController {
     private var window: NSWindow?
     private var cancellable: AnyCancellable?
     private var latestRect: GridRect
-    private let defaultWindowSize = NSSize(width: 240, height: 180)
+    private let defaultWindowSize = NSSize(width: 360, height: 320)
 
     init(zoomController: ZoomController) {
         self.zoomController = zoomController


### PR DESCRIPTION
## Summary
- correct the overlay highlight conversion so grid rows match keyboard input orientation
- enlarge the zoom preview view and window for easier target verification
- document the corrected grid alignment and larger preview in the README

## Testing
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929a1928250832b814bba57f9c48d48)